### PR TITLE
logs heap usage when CLAY_LOG_HEAP=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,32 @@ loggingInstance('error', new Error('oh no!'));
 
 This property on the output log message is meant to make the logs more human searchable when using grep or importing into an ELK-like tool. Rather than making people remember the association between `level` and the different levels meanings, we supply a human-readable property.
 
-## Pretty Printing
+## Environment Variables
+
+| **Config Value**        | **Decription**                                     |
+| ----------------------- | -------------------------------------------------- |
+| `CLAY_LOG_HEAP`         | Set to '1' to enable heap logging.                 |
+| `CLAY_LOG_PRETTY`       | Set to a 'truthy' value to enable pretty-printing. |
+
+
+#### Heap Logging
+
+If `CLAY_LOG_HEAP` is set to "1" the following additional heap statistics will
+be included:
+```json
+{
+    "does_zap_garbage": 0,
+    "heap_size_limit": 0,
+    "malloced_memory": 0,
+    "peak_malloced_memory": 0,
+    "total_available_size": 0,
+    "total_heap_size": 0,
+    "total_heap_size_executable": 0,
+    "total_physical_size": 0,
+    "used_heap_size": 0
+}
+```
+
+#### Pretty Printing
 
 If you don't pass in a `pretty` property, pretty printing will controlled by the `CLAY_LOG_PRETTY` environment variable. The logs will be printed in human readable form. Otherwise they will be regular PinoJS JSON strings.

--- a/test.js
+++ b/test.js
@@ -145,6 +145,51 @@ describe(dirname, function () {
       log();
       sinon.assert.calledOnce(fakeLogInstance.error);
     });
+
+    it('logs memory usage if CLAY_LOG_HEAP is set to "1"', function () {
+      process.env.CLAY_LOG_HEAP = '1';
+      const fakeLogInstance = {
+          info: sinon.stub()
+        },
+        log = fn(fakeLogInstance),
+        data = { some: 'data' },
+        expected = {
+          _label: 'INFO',
+          meta: {
+            does_zap_garbage: sinon.match.number,
+            heap_size_limit: sinon.match.number,
+            malloced_memory: sinon.match.number,
+            peak_malloced_memory: sinon.match.number,
+            total_available_size: sinon.match.number,
+            total_heap_size: sinon.match.number,
+            total_heap_size_executable: sinon.match.number,
+            total_physical_size: sinon.match.number,
+            used_heap_size: sinon.match.number
+          },
+          some: 'data'
+        };
+
+      log('info', 'message', data);
+      sinon.assert.calledOnce(fakeLogInstance.info);
+      sinon.assert.calledWith(fakeLogInstance.info, expected, 'message');
+    });
+
+    it('doesn\'t log memory usage if CLAY_LOG_HEAP != "1"', function () {
+      process.env.CLAY_LOG_HEAP = '0';
+      const fakeLogInstance = {
+          info: sinon.stub()
+        },
+        log = fn(fakeLogInstance),
+        data = { some: 'data' };
+
+      log('info', 'message', data);
+      sinon.assert.calledOnce(fakeLogInstance.info);
+      sinon.assert.neverCalledWith(
+        fakeLogInstance.info,
+        { used_heap_size: sinon.match.any },
+        'message'
+      );
+    });
   });
 
   describe('getLogger', function () {


### PR DESCRIPTION
This commit introduces an optional flag to include heap context for
each line logged. The flag could be useful for tracking down memory
leaks.

For example, one could isolate all of the logs for a particular PID and
then graph the memory use over time, noting large deltas between
messages.