### PR TITLE
bugfix: addresses invalid 'require' for frontend usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,13 @@
 
 var pino = require('pino'), // Can be overwritten for testing
   logger, // Will be overwritten during setup
-  v8 = require('v8');
+  v8;
+
+try {
+  v8 = require(require.resolve('v8'));
+} catch (err) {
+  v8 = null;
+}
 
 /**
  * allow passing in a different output to stream to
@@ -36,11 +42,11 @@ function checkArgs(args) {
 /**
  * enrich the log metadata with additional context about memory use,
  * this may be useful for tracking memory leaks.
- * @param {Object} meta
+ * @param {Object} data
  * @return {Object}
  */
-function addHeap(meta) {
-  return Object.assign(meta, v8.getHeapStatistics());
+function addHeap(data) {
+  return v8 ? Object.assign(data, v8.getHeapStatistics()) : data;
 }
 
 /**
@@ -127,7 +133,7 @@ function log(instanceLog) {
 
     // Include heap info if configured.
     if (process.env.CLAY_LOG_HEAP === '1') {
-      data.meta = addHeap(data.meta || {});
+      data = addHeap(data);
     }
 
     // Log it

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-log",
-  "version": "1.4.1-3",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-log",
-  "version": "1.4.0",
+  "version": "1.4.1-3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-log",
-  "version": "1.4.0",
+  "version": "1.4.1-3",
   "description": "An isomorphic logging module for Clay projects",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-log",
-  "version": "1.4.1-3",
+  "version": "1.4.1",
   "description": "An isomorphic logging module for Clay projects",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -155,17 +155,15 @@ describe(dirname, function () {
         data = { some: 'data' },
         expected = {
           _label: 'INFO',
-          meta: {
-            does_zap_garbage: sinon.match.number,
-            heap_size_limit: sinon.match.number,
-            malloced_memory: sinon.match.number,
-            peak_malloced_memory: sinon.match.number,
-            total_available_size: sinon.match.number,
-            total_heap_size: sinon.match.number,
-            total_heap_size_executable: sinon.match.number,
-            total_physical_size: sinon.match.number,
-            used_heap_size: sinon.match.number
-          },
+          does_zap_garbage: sinon.match.number,
+          heap_size_limit: sinon.match.number,
+          malloced_memory: sinon.match.number,
+          peak_malloced_memory: sinon.match.number,
+          total_available_size: sinon.match.number,
+          total_heap_size: sinon.match.number,
+          total_heap_size_executable: sinon.match.number,
+          total_physical_size: sinon.match.number,
+          used_heap_size: sinon.match.number,
           some: 'data'
         };
 


### PR DESCRIPTION
When 'clay-log' is used on the frontend the 'v8' module is not going to
be avaiable. This commit addresses that breaking change.