### PR TITLE
modifies CLAY_LOG_PRETTY behavior to match docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,15 @@ function getOutput(args) {
  * @return {Boolean}
  */
 function getPrettyPrint(args) {
-  return args.pretty || process.env.CLAY_LOG_PRETTY && (process.versions && process.versions.node);
+  if (!process.versions || !process.versions.node) {
+    return false;  // No pretty logging on the client-side.
+  } else if (args.pretty === true || args.pretty === false) {
+    return args.pretty;
+  } else if (process.env.CLAY_LOG_PRETTY) {
+    return process.env.CLAY_LOG_PRETTY !== 'false';
+  } else {
+    return false;
+  }
 }
 
 /**

--- a/test.js
+++ b/test.js
@@ -51,18 +51,38 @@ describe(dirname, function () {
       expect(cb).to.not.throw(Error);
     });
 
-    it('calls pino.pretty function if `prettyPrint` is set to true', function () {
-      process.env.CLAY_LOG_PRETTY = true;
-      fn({ name: 'test', prettyPrint: true });
+    it('calls pino.pretty function if `CLAY_LOG_PRETTY` is set to "true"', function () {
+      process.env.CLAY_LOG_PRETTY = 'true';
+      fn({ name: 'test' });
       sinon.assert.calledOnce(fakeLog.pretty);
       sinon.assert.calledOnce(pipeSpy);
       delete process.env.CLAY_LOG_PRETTY;
+    });
+
+    it('doesn\'t call pino.pretty function if `CLAY_LOG_PRETTY` is set to "false"', function () {
+      process.env.CLAY_LOG_PRETTY = 'false';
+      fn({ name: 'test'});
+      sinon.assert.notCalled(fakeLog.pretty);
+      delete process.env.CLAY_LOG_PRETTY;
+    });
+
+    it('doesn\'t call pino.pretty function if `CLAY_LOG_PRETTY` is not set', function () {
+      delete process.env.CLAY_LOG_PRETTY;
+      fn({ name: 'test'});
+      sinon.assert.notCalled(fakeLog.pretty);
     });
 
     it('calls pino.pretty function if `pretty` is passed into init', function () {
       fn({ name: 'test', pretty: true });
       sinon.assert.calledOnce(fakeLog.pretty);
       sinon.assert.calledOnce(pipeSpy);
+    });
+
+    it('doesn\'t call pino.pretty function if `pretty` is false and CLAY_LOG_PRETTY is "true"', function () {
+      process.env.CLAY_LOG_PRETTY = 'true';
+      fn({ name: 'test', pretty: false });
+      sinon.assert.notCalled(fakeLog.pretty);
+      delete process.env.CLAY_LOG_PRETTY;
     });
 
     it('calls pino.child function if `meta` object is passed in', function () {


### PR DESCRIPTION
The clay-log documentation states that `CLAY_LOG_PRETTY` is a fallback
value for cases where the `pretty` argument is not explicitly provided
to the initialized logger. This commit addresses a bug where an
explicit `false` argument would be overridden by `CLAY_LOG_PRETTY`.

This commit also addresses the fact that it's not possible to explitly
set `CLAY_LOG_PRETTY` to a `false` value (the string 'false' is
truth-y).

I tried to come up with an elegant way to do this-- but coercing a `string` to `boolean` is always kind of messy (do we accept `"Y"`, `"y"`, `"False"`, `"false"`, `"0"`, `"f"`, etc...).

This approach treats `CLAY_LOG_PRETTY="false"` as `false`, `CLAY_LOG_PRETTY=` as `false`, and any other string value as `true`.

I'm generally in favor of using 0/1 for environment variable booleans and coercing them to integers, but that ship might've sailed for `clay-log`!