### PR TITLE
provides plug-in system for clay-log

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,11 @@ jobs:
     steps:
       - checkout
       - run: npm ci
-      - run: npm test
+      - run:
+          name: Test Node10
+          command: npm test
+          environment:
+            NODE_ENV: test
 
   test_node_12:
     docker:
@@ -26,7 +30,11 @@ jobs:
     steps:
       - checkout
       - run: npm ci
-      - run: npm test
+      - run:
+          name: Test Node12
+          command: npm test
+          environment:
+            NODE_ENV: test
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,7 @@ jobs:
     steps:
       - checkout
       - run: npm ci
-      - run:
-          name: Test Node10
-          command: npm test
-          environment:
-            NODE_ENV: test
+      - run: npm test
 
   test_node_12:
     docker:
@@ -30,11 +26,7 @@ jobs:
     steps:
       - checkout
       - run: npm ci
-      - run:
-          name: Test Node12
-          command: npm test
-          environment:
-            NODE_ENV: test
+      - run: npm test
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+---
+version: 2
+
+templates:
+  filter_all: &filter_all
+    filters:
+      tags:
+        only: /.*/
+      branches:
+        only: /.*/
+
+jobs:
+  test_node_10:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/src
+    steps:
+      - checkout
+      - run: npm ci
+      - run: npm test
+
+  test_node_12:
+    docker:
+      - image: circleci/node:12
+    working_directory: ~/src
+    steps:
+      - checkout
+      - run: npm ci
+      - run: npm test
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test_node_10:
+          <<: *filter_all
+      - test_node_12:
+          <<: *filter_all

--- a/.eslintrc
+++ b/.eslintrc
@@ -51,7 +51,7 @@
     "no-trailing-spaces": 2,
     "no-underscore-dangle": 0,
     "no-unneeded-ternary": 1,
-    "one-var": 2,
+    "one-var": 0,
     "quotes": [2, "single", "avoid-escape"],
     "semi": [2, "always"],
     "keyword-spacing": 2,

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.circleci
+.gitignore
+mocha.opts
+test.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - '8'

--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ This property on the output log message is meant to make the logs more human sea
 | ----------------------- | -------------------------------------------------- |
 | `CLAY_LOG_HEAP`         | Set to '1' to enable heap logging.                 |
 | `CLAY_LOG_PRETTY`       | Set to a 'truthy' value to enable pretty-printing. |
+| `CLAY_LOG_SENTRY_DSN`   | Error-level messages will be reported to Sentry if provided. |
+
+> Note: `CLAY_LOG_SENTRY_DSN` requires your project to include `@sentry/node` in `package.json`.
 
 
 #### Heap Logging

--- a/README.md
+++ b/README.md
@@ -134,9 +134,6 @@ This property on the output log message is meant to make the logs more human sea
 | ----------------------- | -------------------------------------------------- |
 | `CLAY_LOG_HEAP`         | Set to '1' to enable heap logging.                 |
 | `CLAY_LOG_PRETTY`       | Set to a 'truthy' value to enable pretty-printing. |
-| `CLAY_LOG_SENTRY_DSN`   | Error-level messages will be reported to Sentry if provided. |
-
-> Note: `CLAY_LOG_SENTRY_DSN` requires your project to include `@sentry/node` in `package.json`.
 
 
 #### Heap Logging

--- a/index.js
+++ b/index.js
@@ -89,9 +89,9 @@ function initPlugins() {
   const CLAY_LOG_PLUGINS = process.env.CLAY_LOG_PLUGINS || '';
   const modules = CLAY_LOG_PLUGINS
     .split(',')
+    .map(module => module.trim())
     .filter(module => !!module)
     .filter(module => module[0] != '_') // "_" is used to reserve the private namespace.
-    .map(module => module.trim())
     .map((module) => {
       try {
         return require(`./plugins/${module}`);

--- a/index.js
+++ b/index.js
@@ -86,10 +86,11 @@ function init(args) {
  * @return {function}
  */
 function initPlugins() {
-  const CLAY_LOG_PLUGINS = process.env.CLAY_LOG_PLUGINS || 'sentry,heap';
+  const CLAY_LOG_PLUGINS = process.env.CLAY_LOG_PLUGINS || '';
   const modules = CLAY_LOG_PLUGINS
     .split(',')
     .filter(module => !!module)
+    .filter(module => module[0] != '_')
     .map(module => module.trim())
     .map((module) => {
       try {

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ function initPlugins() {
   } else if (modules.length == 1) {
     return modules[0];
   } else {
-    return modules.reduceRight((a, b) => (...args) => b(a(...args)));
+    return modules.reduce((a, b) => (...args) => b(a(...args)));
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function initPlugins() {
   const modules = CLAY_LOG_PLUGINS
     .split(',')
     .filter(module => !!module)
-    .filter(module => module[0] != '_')
+    .filter(module => module[0] != '_') // "_" is used to reserve the private namespace.
     .map(module => module.trim())
     .map((module) => {
       try {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function getOutput(args) {
  */
 function getPrettyPrint(args) {
   if (!process.versions || !process.versions.node) {
-    return false;  // No pretty logging on the client-side.
+    return false; // No pretty logging on the client-side.
   } else if (args.pretty === true || args.pretty === false) {
     return args.pretty;
   } else if (process.env.CLAY_LOG_PRETTY) {
@@ -95,7 +95,7 @@ function initPlugins() {
     .map((module) => {
       try {
         return require(`./plugins/${module}`);
-      } catch {
+      } catch (err) {
         logger.error(`Could not locate clay-log plugin ${module}.`);
       }
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,87 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sentry/core": {
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.24.2.tgz",
+      "integrity": "sha512-nuAwCGU1l9hgMinl5P/8nIQGRXDP2FI9cJnq5h1qiP/XIOvJkJz2yzBR6nTyqr4vBth0tvxQJbIpDNGd7vHJLg==",
+      "dev": true,
+      "requires": {
+        "@sentry/hub": "5.24.2",
+        "@sentry/minimal": "5.24.2",
+        "@sentry/types": "5.24.2",
+        "@sentry/utils": "5.24.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.24.2.tgz",
+      "integrity": "sha512-xmO1Ivvpb5Qr9WgekinuZZlpl9Iw7iPETUe84HQOhUrXf+2gKO+LaUYMMsYSVDwXQEmR6/tTMyOtS6iavldC6w==",
+      "dev": true,
+      "requires": {
+        "@sentry/types": "5.24.2",
+        "@sentry/utils": "5.24.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.24.2.tgz",
+      "integrity": "sha512-biFpux5bI3R8xiD/Zzvrk1kRE6bqPtfWXmZYAHRtaUMCAibprTKSY9Ta8QYHynOAEoJ5Akedy6HUsEkK5DoZfA==",
+      "dev": true,
+      "requires": {
+        "@sentry/hub": "5.24.2",
+        "@sentry/types": "5.24.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.24.2.tgz",
+      "integrity": "sha512-ddfU2tLTvhnY+NqzLIA/gxMt/uxq7R204Nb2J5qqE0WAgbh0dtylNAzfKZTizLdbZfRnpeISmd+CBILh3tavog==",
+      "dev": true,
+      "requires": {
+        "@sentry/core": "5.24.2",
+        "@sentry/hub": "5.24.2",
+        "@sentry/tracing": "5.24.2",
+        "@sentry/types": "5.24.2",
+        "@sentry/utils": "5.24.2",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/tracing": {
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.24.2.tgz",
+      "integrity": "sha512-1uDgvGGVF8lb3hRXbhNnns+8DBUKjhRKOFR5Z3RExjrDFYTDbHmoNtV73Q12Ra+Iht9HTZnIBOqYD3oSZIbJ0w==",
+      "dev": true,
+      "requires": {
+        "@sentry/hub": "5.24.2",
+        "@sentry/minimal": "5.24.2",
+        "@sentry/types": "5.24.2",
+        "@sentry/utils": "5.24.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.24.2.tgz",
+      "integrity": "sha512-HcOK00R0tQG5vzrIrqQ0jC28+z76jWSgQCzXiessJ5SH/9uc6NzdO7sR7K8vqMP2+nweCHckFohC8G0T1DLzuQ==",
+      "dev": true
+    },
+    "@sentry/utils": {
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.24.2.tgz",
+      "integrity": "sha512-oPGde4tNEDHKk0Cg9q2p0qX649jLDUOwzJXHKpd0X65w3A6eJByDevMr8CSzKV9sesjrUpxqAv6f9WWlz185tA==",
+      "dev": true,
+      "requires": {
+        "@sentry/types": "5.24.2",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -42,6 +123,32 @@
         }
       }
     },
+    "agent-base": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+      "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+      "dev": true,
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -67,9 +174,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -95,7 +202,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "requires": {
-        "color-convert": "1.9.1"
+        "color-convert": "^1.9.0"
       }
     },
     "argparse": {
@@ -104,7 +211,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "assertion-error": {
@@ -178,7 +285,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -200,16 +307,16 @@
       "integrity": "sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=",
       "dev": true,
       "requires": {
-        "cssmin": "0.3.2",
-        "jsmin": "1.0.1",
-        "jxLoader": "0.1.1",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "timespan": "2.3.0",
-        "uglify-js": "1.3.5",
-        "walker": "1.0.7",
-        "winston": "2.4.0",
-        "wrench": "1.3.9"
+        "cssmin": "0.3.x",
+        "jsmin": "1.x",
+        "jxLoader": "*",
+        "moo-server": "*",
+        "promised-io": "*",
+        "timespan": "2.x",
+        "uglify-js": "1.x",
+        "walker": "1.x",
+        "winston": "*",
+        "wrench": "1.3.x"
       },
       "dependencies": {
         "uglify-js": {
@@ -249,8 +356,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chai": {
@@ -259,12 +366,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chalk": {
@@ -272,9 +379,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
       "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
       "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.2.0"
+        "ansi-styles": "^3.2.0",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.2.0"
       }
     },
     "chardet": {
@@ -317,8 +424,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -342,7 +449,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -379,6 +486,12 @@
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
       }
+    },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -430,7 +543,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -438,6 +551,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "dev-null": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dev-null/-/dev-null-0.1.1.tgz",
+      "integrity": "sha1-WiBc48Ky73e2I41roXnrdMag6Bg="
     },
     "diff": {
       "version": "3.2.0",
@@ -459,7 +577,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "escape-string-regexp": {
@@ -473,11 +591,11 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
       },
       "dependencies": {
         "esprima": {
@@ -688,7 +806,7 @@
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "samsam": "1.x"
       }
     },
     "fs.realpath": {
@@ -715,12 +833,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
@@ -747,10 +865,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "source-map": {
@@ -759,7 +877,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -783,6 +901,33 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -811,8 +956,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -890,20 +1035,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.10.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.0",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -918,11 +1063,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -937,7 +1082,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -954,8 +1099,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsmin": {
@@ -988,10 +1133,10 @@
       "integrity": "sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=",
       "dev": true,
       "requires": {
-        "js-yaml": "0.3.7",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "walker": "1.0.7"
+        "js-yaml": "0.3.x",
+        "moo-server": "1.3.x",
+        "promised-io": "*",
+        "walker": "1.x"
       },
       "dependencies": {
         "js-yaml": {
@@ -1009,7 +1154,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -1025,8 +1170,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
@@ -1064,13 +1209,19 @@
         "yallist": "^2.1.2"
       }
     },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=",
+      "dev": true
+    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "mimic-fn": {
@@ -1085,7 +1236,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1134,7 +1285,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -1175,11 +1326,11 @@
       "integrity": "sha512-ewMXDEflamPfDbh7y08tbrJCAiN87SEz388s2cG4ODYnA+ge6QB8pvjo+Pkv9844qMB+NPE9O8tMyIEle0vyew==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "just-extend": "1.1.27",
-        "lolex": "2.3.2",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "@sinonjs/formatio": "^2.0.0",
+        "just-extend": "^1.1.27",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       }
     },
     "nopt": {
@@ -1188,7 +1339,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9"
+        "abbrev": "1"
       }
     },
     "object-assign": {
@@ -1202,7 +1353,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -1220,8 +1371,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -1238,12 +1389,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-tmpdir": {
@@ -1292,14 +1443,14 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-4.13.0.tgz",
       "integrity": "sha512-o8csWL24S2ziLj8QXWL3wIQnEesgS2fGCC4oQaLDXZUOsoEE3UNeGDvi8yhe03CWcLiwyUDTUPpGjQtSuzQbOw==",
       "requires": {
-        "chalk": "2.3.1",
-        "fast-json-parse": "1.0.3",
-        "fast-safe-stringify": "1.2.3",
-        "flatstr": "1.0.5",
-        "pino-std-serializers": "1.0.0",
-        "pump": "2.0.1",
-        "quick-format-unescaped": "1.1.2",
-        "split2": "2.2.0"
+        "chalk": "^2.3.0",
+        "fast-json-parse": "^1.0.3",
+        "fast-safe-stringify": "^1.2.3",
+        "flatstr": "^1.0.5",
+        "pino-std-serializers": "^1.0.0",
+        "pump": "^2.0.1",
+        "quick-format-unescaped": "^1.1.2",
+        "split2": "^2.2.0"
       }
     },
     "pino-std-serializers": {
@@ -1347,8 +1498,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "quick-format-unescaped": {
@@ -1356,7 +1507,7 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-1.1.2.tgz",
       "integrity": "sha1-DKWB3jF0vs7yWsPC6JVjQjgdtpg=",
       "requires": {
-        "fast-safe-stringify": "1.2.3"
+        "fast-safe-stringify": "^1.0.8"
       }
     },
     "readable-stream": {
@@ -1364,13 +1515,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
       "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "repeat-string": {
@@ -1419,7 +1570,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -1521,17 +1672,17 @@
       "integrity": "sha512-/flfGfIxIRXSvZBHJzIf3iAyGYkmMQq6SQjA0cx9SOuVuq+4ZPPO4LJtH1Ce0Lznax1KSG1U6Dad85wIcSW19w==",
       "dev": true,
       "requires": {
-        "build": "0.1.4",
-        "diff": "3.2.0",
+        "build": "^0.1.4",
+        "diff": "^3.1.0",
         "formatio": "1.2.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.3.2",
-        "native-promise-only": "0.8.1",
-        "nise": "1.2.6",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.3.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.1.2",
+        "native-promise-only": "^0.8.1",
+        "nise": "^1.0.1",
+        "path-to-regexp": "^1.7.0",
+        "samsam": "^1.1.3",
         "text-encoding": "0.6.4",
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "slice-ansi": {
@@ -1550,7 +1701,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "split2": {
@@ -1558,7 +1709,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.2"
       }
     },
     "sprintf-js": {
@@ -1588,7 +1739,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -1619,7 +1770,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
       "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "table": {
@@ -1659,8 +1810,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.4",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "timespan": {
@@ -1684,13 +1835,19 @@
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
+    "tslib": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -1712,9 +1869,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -1744,7 +1901,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "which": {
@@ -1753,7 +1910,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "window-size": {
@@ -1769,12 +1926,12 @@
       "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
       "dev": true,
       "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "stack-trace": "0.0.10"
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
       },
       "dependencies": {
         "async": {
@@ -1829,9 +1986,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-log",
-  "version": "1.4.2",
+  "version": "1.5.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -555,7 +555,8 @@
     "dev-null": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dev-null/-/dev-null-0.1.1.tgz",
-      "integrity": "sha1-WiBc48Ky73e2I41roXnrdMag6Bg="
+      "integrity": "sha1-WiBc48Ky73e2I41roXnrdMag6Bg=",
+      "dev": true
     },
     "diff": {
       "version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,14 +85,41 @@
         "tslib": "^1.9.3"
       }
     },
-    "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "type-detect": "4.0.8"
       }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.0.9",
@@ -101,9 +128,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -213,6 +240,12 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -685,9 +718,9 @@
       }
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esquery": {
@@ -1095,9 +1128,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1123,9 +1156,9 @@
       "dev": true
     },
     "just-extend": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
       "dev": true
     },
     "jxLoader": {
@@ -1176,9 +1209,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.get": {
@@ -1247,12 +1280,20 @@
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "mocha": {
@@ -1279,6 +1320,15 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
           "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
           "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "supports-color": {
           "version": "5.4.0",
@@ -1322,16 +1372,27 @@
       "dev": true
     },
     "nise": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.6.tgz",
-      "integrity": "sha512-ewMXDEflamPfDbh7y08tbrJCAiN87SEz388s2cG4ODYnA+ge6QB8pvjo+Pkv9844qMB+NPE9O8tMyIEle0vyew==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "just-extend": "^1.1.27",
-        "lolex": "^2.3.2",
-        "path-to-regexp": "^1.7.0",
-        "text-encoding": "^0.6.4"
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^5.0.1",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+          "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        }
       }
     },
     "nopt": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-log",
-  "version": "1.4.2",
+  "version": "1.5.0-0",
   "description": "An isomorphic logging module for Clay projects",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
   "homepage": "https://github.com/clay/clay-log#readme",
   "dependencies": {
     "ansi-styles": "^3.2.0",
-    "dev-null": "^0.1.1",
     "pino": "^4.7.1"
   },
   "devDependencies": {
     "@sentry/node": "^5.24.2",
     "chai": "^4.1.2",
+    "dev-null": "^0.1.1",
     "eslint": "^4.7.1",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
   "homepage": "https://github.com/clay/clay-log#readme",
   "dependencies": {
     "ansi-styles": "^3.2.0",
+    "dev-null": "^0.1.1",
     "pino": "^4.7.1"
   },
   "devDependencies": {
+    "@sentry/node": "^5.24.2",
     "chai": "^4.1.2",
     "eslint": "^4.7.1",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
     "sinon": "^3.3.0"
+  },
+  "peerDependencies": {
+    "@sentry/node": "^5.23.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,10 @@
   },
   "peerDependencies": {
     "@sentry/node": "^5.23.0"
+  },
+  "peerDependenciesMeta": {
+    "@sentry/node": {
+      "optional": true
+    }
   }
 }

--- a/plugins/_utils.js
+++ b/plugins/_utils.js
@@ -1,15 +1,22 @@
+const { noop } = require('pino/lib/tools');
+
 function wrap(func, levels = []) {
   levels = new Set(levels);
 
   return function (logger) {
     Object.keys(logger.levels.values)
       .filter(level => levels.has(level) || levels.size == 0)
-      .filter(level => logger[level].name !== 'noop')
+      .filter(level => logger[level] !== noop)
       .forEach((level) => {
         const _level = logger[level];
         logger[level] = function(data, msg) {
             func(data, msg);
             return _level.apply(logger, [data, msg]);
+        }
+        // Sinon needs to spy on the original function, not the wrapped function.
+        // This conditional allows us to test if data was enriched.
+        if (process.env.NODE_ENV === 'test') {
+          logger[level]._original = _level;
         }
       });
     return logger;

--- a/plugins/_utils.js
+++ b/plugins/_utils.js
@@ -1,0 +1,15 @@
+function wrap(logger, levels, func) {
+  levels = new Set(levels);
+
+  Object.keys(logger.levels.values)
+    .filter(levels.has)
+    .filter(level => logger[level].name !== 'noop')
+    .forEach((level) => {
+      const _level = logger[level];
+      logger[level] = function(data, msg) {
+          func(data, msg);
+          return _level.apply(logger, [data, msg]);
+      }
+    });
+  return logger;
+}

--- a/plugins/_utils.js
+++ b/plugins/_utils.js
@@ -1,5 +1,13 @@
 const { noop } = require('pino/lib/tools');
 
+/**
+ * Applies plug-in code to select active log-levels before eventually
+ * calling the core pino logger.
+ *
+ * @param {function} func: The plug-in function.
+ * @param {string[]} levels: An optional array of log-levels to apply a plug-in to.
+ * @returns {Object} The wrapped pino instance.
+ */
 function wrap(func, levels = []) {
   levels = new Set(levels);
 

--- a/plugins/_utils.js
+++ b/plugins/_utils.js
@@ -1,15 +1,21 @@
-function wrap(logger, levels, func) {
+function wrap(func, levels = []) {
   levels = new Set(levels);
 
-  Object.keys(logger.levels.values)
-    .filter(levels.has)
-    .filter(level => logger[level].name !== 'noop')
-    .forEach((level) => {
-      const _level = logger[level];
-      logger[level] = function(data, msg) {
-          func(data, msg);
-          return _level.apply(logger, [data, msg]);
-      }
-    });
-  return logger;
+  return function (logger) {
+    Object.keys(logger.levels.values)
+      .filter(level => levels.has(level) || levels.size == 0)
+      .filter(level => logger[level].name !== 'noop')
+      .forEach((level) => {
+        const _level = logger[level];
+        logger[level] = function(data, msg) {
+            func(data, msg);
+            return _level.apply(logger, [data, msg]);
+        }
+      });
+    return logger;
+  };
+}
+
+module.exports = {
+  wrap
 }

--- a/plugins/heap.js
+++ b/plugins/heap.js
@@ -4,6 +4,12 @@ const v8 = require('v8');
 
 const { wrap } = require('./_utils');
 
+/**
+ * Adds memory-use data from v8.getHeapStatistics to a log's context
+ *
+ * @param {object} data: The data to enhance.
+ * @param {string} msg: The string summary of the log line.
+ */
 function wrapper(data, msg) {
   data = Object.assign(data, v8.getHeapStatistics());
 }

--- a/plugins/heap.js
+++ b/plugins/heap.js
@@ -2,17 +2,10 @@
 
 const v8 = require('v8');
 
-function wrapper(logger) {
-  Object.keys(logger.levels.values)
-    .filter(level => logger[level].name !== 'noop')
-    .forEach((level) => {
-      const _level = logger[level];
-      logger[level] = function(data, msg) {
-        data = Object.assign(data, v8.getHeapStatistics());
-        return _level.apply(logger, [data, msg]);
-      };
-    });
-  return logger;
+const { wrap } = require('./_utils');
+
+function wrapper(data, msg) {
+  data = Object.assign(data, v8.getHeapStatistics());
 }
 
-module.exports = wrapper;
+module.exports = wrap(wrapper);

--- a/plugins/heap.js
+++ b/plugins/heap.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const v8 = require('v8');
+
+function wrapper(logger) {
+  Object.keys(logger.levels.values)
+    .filter(level => logger[level].name !== 'noop')
+    .forEach((level) => {
+      const _level = logger[level];
+      logger[level] = function(data, msg) {
+        data = Object.assign(data, v8.getHeapStatistics());
+        return _level.apply(logger, [data, msg]);
+      };
+    });
+  return logger;
+}
+
+module.exports = wrapper;

--- a/plugins/sentry.js
+++ b/plugins/sentry.js
@@ -9,6 +9,12 @@ Sentry.init({
   onunhandledrejection: false
 });
 
+/**
+ * Reports error-level logs to Sentry.
+ *
+ * @param {object} data: The Error or data to report.
+ * @param {string} msg: The name of the Error.
+ */
 function wrapper(data, msg) {
   if (msg instanceof Error) {
     Sentry.captureException(msg, { extra: data });

--- a/plugins/sentry.js
+++ b/plugins/sentry.js
@@ -1,24 +1,23 @@
 'use strict';
 
 const Sentry = require('@sentry/node');
+
+const { wrap } = require('./_utils');
+
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   onunhandledrejection: false
 });
 
-function wrapper(logger) {
-  const _error = logger.error;
-  logger.error = function(data, msg) {
-    if (msg instanceof Error) {
-      Sentry.captureException(msg, { extra: data });
-    } else {
-      const err = new Error(msg);
-      err.stack = data instanceof Object ? data.stack : '';
-      Sentry.captureException(err, { extra: data });
-    }
-    return _error.apply(logger, [data, msg]);
-  };
-  return logger;
+
+function wrapper(data, msg) {
+  if (msg instanceof Error) {
+    Sentry.captureException(msg, { extra: data });
+  } else {
+    const err = new Error(msg);
+    err.stack = data instanceof Object ? data.stack : '';
+    Sentry.captureException(err, { extra: data });
+  }
 }
 
-module.exports = wrapper;
+module.exports = wrap(wrapper, ['error']);

--- a/plugins/sentry.js
+++ b/plugins/sentry.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const Sentry = require('@sentry/node');
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  onunhandledrejection: false
+});
+
+function wrapper(logger) {
+  const _error = logger.error;
+  logger.error = function(data, msg) {
+    if (msg instanceof Error) {
+      Sentry.captureException(msg, { extra: data });
+    } else {
+      const err = new Error(msg);
+      err.stack = data instanceof Object ? data.stack : '';
+      Sentry.captureException(err, { extra: data });
+    }
+    return _error.apply(logger, [data, msg]);
+  };
+  return logger;
+}
+
+module.exports = wrapper;

--- a/plugins/sentry.js
+++ b/plugins/sentry.js
@@ -9,7 +9,6 @@ Sentry.init({
   onunhandledrejection: false
 });
 
-
 function wrapper(data, msg) {
   if (msg instanceof Error) {
     Sentry.captureException(msg, { extra: data });

--- a/test.js
+++ b/test.js
@@ -47,6 +47,7 @@ describe(dirname, function () {
   beforeEach(function () {
     process.env.NODE_ENV = 'test';
     process.env.CLAY_LOG_PLUGINS = '';
+    process.env.CLAY_LOG_PLUGINS_PATH = '';
     sandbox = sinon.sandbox.create();
     pipeSpy = sandbox.spy();
     childSpy = sandbox.spy();
@@ -309,18 +310,6 @@ describe(dirname, function () {
         fs.unlinkSync(path.join(dirname, '_utils.js'));
         fs.rmdirSync(dirname, { recursive: true });
       });
-    });
-  });
-
-  describe('getLogger', function () {
-    const fn = lib[this.title];
-
-    it('returns the logger', function () {
-      var fakeLogger = sandbox.stub().returns('hello');
-
-      lib.setLogger(fakeLogger);
-      lib.init({name: 'testing'});
-      expect(fn()).to.equal('hello');
     });
   });
 

--- a/test.js
+++ b/test.js
@@ -47,7 +47,6 @@ describe(dirname, function () {
   beforeEach(function () {
     process.env.NODE_ENV = 'test';
     process.env.CLAY_LOG_PLUGINS = '';
-    process.env.CLAY_LOG_PLUGINS_PATH = '';
     sandbox = sinon.sandbox.create();
     pipeSpy = sandbox.spy();
     childSpy = sandbox.spy();
@@ -291,7 +290,7 @@ describe(dirname, function () {
       sinon.assert.calledWith(fakeLogInstance.info, expected, 'message');
     });
 
-    it('loads custom plugins with CLAY_LOG_PLUGINS_PATH', function () {
+    it('loads custom plugins with CLAY_LOG_PLUGINS_PATH', function (done) {
       process.env.CLAY_LOG_PLUGINS = 'memory';
 
       fs.mkdtemp(path.join('.', '.clay-log-test-'), (err, dirname) => {
@@ -309,7 +308,20 @@ describe(dirname, function () {
         fs.unlinkSync(path.join(dirname, 'memory.js'));
         fs.unlinkSync(path.join(dirname, '_utils.js'));
         fs.rmdirSync(dirname, { recursive: true });
+        done();
       });
+    });
+  });
+
+  describe('getLogger', function () {
+    const fn = lib[this.title];
+
+    it('returns the logger', function () {
+      var fakeLogger = sandbox.stub().returns('hello');
+
+      lib.setLogger(fakeLogger);
+      lib.init({name: 'testing'});
+      expect(fn()).to.equal('hello');
     });
   });
 

--- a/test.js
+++ b/test.js
@@ -1,17 +1,38 @@
 'use strict';
 
 const sinon = require('sinon'),
+  devnull = require('dev-null'),
   dirname = __dirname.split('/').pop(),
   lib = require('./'),
-  expect = require('chai').expect;
+  expect = require('chai').expect,
+  { noop } = require('pino/lib/tools');
 
 describe(dirname, function () {
+  const levels = {
+    trace: 10,
+    debug: 20,
+    info: 30,
+    warn: 40,
+    error: 50,
+    fatal: 60
+  };
   let sandbox, fakeLog, pipeSpy, childSpy;
 
   function createFakeLogger() {
-    var fakeLog = sandbox.stub().returns({
-      child: childSpy
+    const logger = { child: childSpy, levels: { values: levels } };
+
+    Object.keys(levels).forEach((level) => {
+      switch (level) {
+        case 'trace':
+          logger[level] = noop;
+        case 'debug':
+          logger[level] = noop;
+        default:
+          logger[level] = sinon.stub();
+      }
     });
+
+    const fakeLog = sandbox.stub().returns(logger);
 
     fakeLog.pretty = sandbox.stub().returns({
       pipe: pipeSpy
@@ -21,6 +42,8 @@ describe(dirname, function () {
   }
 
   beforeEach(function () {
+    process.env.NODE_ENV = 'test';
+    process.env.CLAY_LOG_PLUGINS = '';
     sandbox = sinon.sandbox.create();
     pipeSpy = sandbox.spy();
     childSpy = sandbox.spy();
@@ -166,11 +189,9 @@ describe(dirname, function () {
       sinon.assert.calledOnce(fakeLogInstance.error);
     });
 
-    it('logs memory usage if CLAY_LOG_HEAP is set to "1"', function () {
-      process.env.CLAY_LOG_HEAP = '1';
-      const fakeLogInstance = {
-          info: sinon.stub()
-        },
+    it('logs memory usage if CLAY_LOG_PLUGINS is set to "heap"', function () {
+      process.env.CLAY_LOG_PLUGINS = 'heap';
+      const fakeLogInstance = createFakeLogger()(),
         log = fn(fakeLogInstance),
         data = { some: 'data' },
         expected = {
@@ -178,6 +199,8 @@ describe(dirname, function () {
           does_zap_garbage: sinon.match.number,
           heap_size_limit: sinon.match.number,
           malloced_memory: sinon.match.number,
+          number_of_detached_contexts: sinon.match.number,
+          number_of_native_contexts: sinon.match.number,
           peak_malloced_memory: sinon.match.number,
           total_available_size: sinon.match.number,
           total_heap_size: sinon.match.number,
@@ -188,15 +211,13 @@ describe(dirname, function () {
         };
 
       log('info', 'message', data);
-      sinon.assert.calledOnce(fakeLogInstance.info);
-      sinon.assert.calledWith(fakeLogInstance.info, expected, 'message');
+      sinon.assert.calledOnce(fakeLogInstance.info._original);
+      sinon.assert.calledWith(fakeLogInstance.info._original, expected, 'message');
     });
 
-    it('doesn\'t log memory usage if CLAY_LOG_HEAP != "1"', function () {
-      process.env.CLAY_LOG_HEAP = '0';
-      const fakeLogInstance = {
-          info: sinon.stub()
-        },
+    it('doesn\'t log memory usage if CLAY_LOG_PLUGINS does not contain "heap"', function () {
+      process.env.CLAY_LOG_PLUGINS = '';
+      const fakeLogInstance = createFakeLogger()(),
         log = fn(fakeLogInstance),
         data = { some: 'data' };
 
@@ -207,6 +228,60 @@ describe(dirname, function () {
         { used_heap_size: sinon.match.any },
         'message'
       );
+    });
+
+    it('logs errors to Sentry if CLAY_LOG_PLUGINS is set to "sentry"', function () {
+      process.env.CLAY_LOG_PLUGINS = 'sentry';
+      const Sentry = require('@sentry/node');
+
+      Sentry.captureException = sinon.stub();
+      const fakeLogInstance = createFakeLogger()(),
+        log = fn(fakeLogInstance),
+        data = { some: 'data' },
+        expected = {
+          _label: 'ERROR',
+          some: 'data'
+        };
+
+      log('error', 'message', data);
+      sinon.assert.calledOnce(fakeLogInstance.error._original);
+      sinon.assert.calledWith(fakeLogInstance.error._original, expected, 'message');
+      sinon.assert.calledOnce(Sentry.captureException);
+      sinon.assert.calledWith(Sentry.captureException, sinon.match.has('stack'), sinon.match.object);
+    });
+
+    it('runs multiple plugins CLAY_LOG_PLUGINS is set to "sentry,heap"', function () {
+      process.env.CLAY_LOG_PLUGINS = 'sentry,heap';
+      const Sentry = require('@sentry/node');
+
+      Sentry.captureException = sinon.stub();
+
+      const fakeLogInstance = createFakeLogger()(),
+        log = fn(fakeLogInstance),
+        data = { some: 'data' };
+
+      log('error', 'message', data);
+      sinon.assert.calledOnce(fakeLogInstance.error._original._original);
+      sinon.assert.calledWith(
+        fakeLogInstance.error._original._original,
+        sinon.match.has('used_heap_size'), 'message'
+      );
+      sinon.assert.calledOnce(Sentry.captureException);
+    });
+
+    it('skips unavailable or invalid CLAY_LOG_PLUGINS', function () {
+      process.env.CLAY_LOG_PLUGINS = 'foo,bar,baz';
+      const fakeLogInstance = createFakeLogger()(),
+        log = fn(fakeLogInstance),
+        data = { some: 'data' },
+        expected = {
+          _label: 'INFO',
+          some: 'data'
+        };
+
+      log('info', 'message', data);
+      sinon.assert.calledOnce(fakeLogInstance.info);
+      sinon.assert.calledWith(fakeLogInstance.info, expected, 'message');
     });
   });
 
@@ -219,6 +294,34 @@ describe(dirname, function () {
       lib.setLogger(fakeLogger);
       lib.init({name: 'testing'});
       expect(fn()).to.equal('hello');
+    });
+  });
+
+  describe('wrap', function () {
+    const fn = require('./plugins/_utils')[this.title];
+    const pino = require('pino');
+    const logger = pino({ name: 'test-wrapper', level: 'warn' }, devnull());
+    const fakeService = sinon.stub();
+
+    function fakePlugin() {
+      fakeService('foo');
+    }
+
+    const wrappedLogger = fn(fakePlugin, ['info', 'warn'])(logger);
+
+    it('does not trigger plugin due to pino log level being set higher than "info"', function () {
+      wrappedLogger.info('test log: ignore this message');
+      sinon.assert.notCalled(fakeService);
+    });
+
+    it('does not trigger plugin due to plugin config excluding "error"', function () {
+      wrappedLogger.error('test log: ignore this message');
+      sinon.assert.notCalled(fakeService);
+    });
+
+    it('trigers the plugin due to pino log level and plugin including "warn"', function () {
+      wrappedLogger.warn('test log: ignore this message');
+      sinon.assert.calledOnce(fakeService);
     });
   });
 });


### PR DESCRIPTION
This PR introduces a simple plug-in system for `clay-log`.
A **plug-in** is just a wrapper function that will be executed before `pino.<level>`.

## Example use cases:

* Enhancing log context with additional data (eg. [plugins/heap.js](https://github.com/clay/clay-log/blob/sentry-integration/plugins/heap.js)).
* Sending error logs to an additional reporting location (eg. [plugins/sentry.js](https://github.com/clay/clay-log/blob/sentry-integration/plugins/sentry.js)).

## How to enable plug-ins:

An environment variable `CLAY_LOG_PLUGINS` accepts a comma-delimited list of values.
Plug-ins will be applied in the order that they are listed in the environment variable.

eg. `CLAY_LOG_PLUGINS=a,b,c` would apply `a.js`, `b.js`, and then `c.js`.
If `a` and `c` both write to `data.message` the value from `c` will appear in the logs.

I chose to use this environment variable pattern vs arguments at `clay-log` initialization because many `amphora`-related projects initialize their own loggers. Environment variables provide the easiest route to ensuring a plug-in is applied to *all* `clay-log` instances in an application.

### Third-Party plug-ins

Developers can also create plug-ins that live in their projects (but are not part of the `clay-log` project).
Doing this is just a matter of creating a directory in their project, eg. `./clay-log-plugins` and setting `CLAY_LOG_PLUGINS_PATH=./clay-log-plugins`.

The README includes instructions for creating these extensions, they are nearly identical to the instructions for developing core plug-ins.

## Performance impact of plugins:

I put together a simple test that writes 100,000 log lines per log-level (500,000 total).
The log-levels tested were `['trace', 'debug', 'info', 'warn', 'error']`.

Each plugin imposes some degree of performance penalty.

### Benchmark: `CLAY_LOG_PLUGINS=`

```
real	0m0.837s
user	0m0.769s
sys	0m0.127s
```

### Benchmark: `CLAY_LOG_PLUGINS=heap`

```
real	0m2.389s
user	0m2.318s
sys	0m0.162s
```

### Benchmark: `CLAY_LOG_PLUGINS=sentry`

```
real	0m6.047s
user	0m6.124s
sys	0m0.262s
```

**Note:** When we remove any `error` level logs from the performance testing the impact of the Sentry plug-in disappears. This suggests that the performance impact is negligible unless an application is producing an unreasonably large number of errors.

```
real	0m0.655s
user	0m0.629s
sys	0m0.086s
```

## Performance: Pre-Plugins vs Post-Plugins

Prior to this PR, we were running a `try/catch` pattern when dealing with `CLAY_LOG_HEAP` dependencies. The numbers below indicate that merging this PR will improve `clay-log` performance when heap logging is disabled _and_ when it is enabled.

### Benchmark: `CLAY_LOG_HEAP=0`

```
real	0m1.088s
user	0m1.068s
sys	0m0.077s
```

### Benchmark: `CLAY_LOG_HEAP=1`

```
real	0m3.232s
user	0m3.082s
sys	0m0.211s
```