### PR TITLE
bugfix: prevent plug-ins from loading client-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ An empty or unset value for `CLAY_LOG_PLUGINS` will disable plugins (the default
 * Plug-ins will only execute on log levels greater-then-or-equal-to what is set in `LOG=`.
 * Plug-ins from `CLAY_LOG_PLUGINS_PATH` will take priority over core plug-ins, be mindful of any naming conflicts.
 * If a plug-in specified in `CLAY_LOG_PLUGINS` is not found a warning message will be logged but application execution will not halt.
+* Plug-ins are only supported **server-side** at the moment, they will not be loaded on the client.
 
 ### Core Plug-ins
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const isNode = typeof process !== 'undefined'
+  && process.versions != null
+  && process.versions.node != null;
+
 var pino = require('pino'), // Can be overwritten for testing
   logger, // Will be overwritten during setup
   plugins;
@@ -164,7 +168,7 @@ function meta(options, logInstance) {
  * @return {Function}
  */
 function log(instanceLog) {
-  if (!plugins) {
+  if (isNode && !plugins) {
     instanceLog = initPlugins()(instanceLog);
   }
 


### PR DESCRIPTION
When `clay-log` is compiled via `claycli` for use in `kiln` the value of `CLAY_LOG_PLUGINS` makes it into `client-env.json`. As a result, we get a ton of errors in the browser console related to plug-in loading.

This commit adds a quick check that will skip plug-in code on the client.

The ideal solution would be to not include `CLAY_LOG_PLUGINS` at all, but that seems like a tougher problem to solve with the build tools in `claycli`.