### PR TITLE
avoids mutating objects passed to clay-log

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const isNode = typeof process !== 'undefined'
+const cloneDeep = require('lodash.clonedeep'),
+  isNode = typeof process !== 'undefined'
   && process.versions != null
   && process.versions.node != null;
 
@@ -173,7 +174,7 @@ function log(instanceLog) {
   }
 
   return function (level, msg, data = {}) {
-    data = Object.assign({}, data);
+    data = cloneDeep(data);
 
     if (level instanceof Error) {
       msg = level;

--- a/index.js
+++ b/index.js
@@ -172,8 +172,8 @@ function log(instanceLog) {
     instanceLog = initPlugins()(instanceLog);
   }
 
-  return function (level, msg, data) {
-    data = data || {};
+  return function (level, msg, data = {}) {
+    data = Object.assign({}, data);
 
     if (level instanceof Error) {
       msg = level;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1214,6 +1214,11 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-log",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-log",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "An isomorphic logging module for Clay projects",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/clay/clay-log#readme",
   "dependencies": {
     "ansi-styles": "^3.2.0",
+    "lodash.clonedeep": "^4.5.0",
     "pino": "^4.7.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -166,7 +166,7 @@ describe(dirname, function () {
 
       log('info', 'message', data);
       sinon.assert.calledOnce(fakeLogInstance.info);
-      sinon.assert.calledWith(fakeLogInstance.info, data, 'message');
+      sinon.assert.calledWith(fakeLogInstance.info, { _label: 'INFO', some: 'data' }, 'message');
     });
 
 
@@ -219,6 +219,16 @@ describe(dirname, function () {
       log('info', 'message', data);
       sinon.assert.calledOnce(fakeLogInstance.info._original);
       sinon.assert.calledWith(fakeLogInstance.info._original, expected, 'message');
+    });
+
+    it('does not mutate the object passed to the logger', function () {
+      process.env.CLAY_LOG_PLUGINS = 'heap';
+      const fakeLogInstance = createFakeLogger()(),
+        log = fn(fakeLogInstance),
+        data = { some: 'data' };
+
+      log('info', 'message', data);
+      expect(data).to.deep.equal({ some: 'data' });
     });
 
     it('doesn\'t log memory usage if CLAY_LOG_PLUGINS does not contain "heap"', function () {


### PR DESCRIPTION
In developing the plug-in system for clay-log I started thinking about
how we might be introducing the opportunity for some unintended
side-effects.

The best practice is definitely to call clay-log using a pattern like
this...

```js
log('info', 'message', { obj });
```

...but in reality there is a lot of code out in the wild doing this:

```js
log('info', 'message', obj);
```

Take the following scenario where `CLAY_LOG_PLUGINS=heap`:

```js
const obj = { 'foo': 'bar' };

log('info', 'Object values', obj);

obj.used_heap_size // This will return a value!
```

I wrote a test to check for mutation introduced by `clay-log` and it
turns out we already had an issue with this in the core library:

```js
const obj = { 'foo': 'bar' };

log('info', 'Object values', obj);

obj._label // This will be set to 'INFO'!
```

---

This commit introduces a place where we copy the provided object,
rather than mutate the object directly. I would've used the spread
syntax but our linter rules did not recognize it (a browser support
safeguard?).