### PR TITLE
fixes bug which dropped non-enumerable fields from 'data' argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,31 @@ The arguments are in the following order:
 2. Message (String)
 3. Accompanying log information (Object)
 
+### Safety Considerations :warning:
+
+The safest way to use the third position argument (`data`) is to wrap an object
+rather than pass an object directly. The object provided should have enumerable properties.
+
+Passing an object directly may result in a thrown error (if it's not really an object).
+```js
+const obj = 'string';
+log('info', 'this is unsafe', obj);  // throws
+```
+
+Passing an object directly may result in mutation. Be mindful of this when utilizing plug-ins.
+```js
+const obj = { key: 'value' };
+log('info', 'this is unsafe', obj);
+obj._label // 'INFO'
+```
+
+These are safer ways to provide the `data` argument.
+```js
+log('info', 'this is safer', { obj });
+log('info', 'this is safer', { ...obj });
+log('error', 'this is safer', { stack: err.stack });
+```
+
 ### Setting Minimum Log Level
 
 For production instances it may not be necessary to log the same messages you do in dev environments. By default, Clay Log will only display `info` and above level logs, but this can be configured with an environment variable. Set `process.env.LOG` to a [corresponding log level](#usage) and that will be the minimum level that appears.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const cloneDeep = require('lodash.clonedeep'),
-  isNode = typeof process !== 'undefined'
+const isNode = typeof process !== 'undefined'
   && process.versions != null
   && process.versions.node != null;
 
@@ -173,8 +172,8 @@ function log(instanceLog) {
     instanceLog = initPlugins()(instanceLog);
   }
 
-  return function (level, msg, data = {}) {
-    data = cloneDeep(data);
+  return function (level, msg, data) {
+    data = data || {};
 
     if (level instanceof Error) {
       msg = level;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1214,11 +1214,6 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/clay/clay-log#readme",
   "dependencies": {
     "ansi-styles": "^3.2.0",
-    "lodash.clonedeep": "^4.5.0",
     "pino": "^4.7.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -166,7 +166,7 @@ describe(dirname, function () {
 
       log('info', 'message', data);
       sinon.assert.calledOnce(fakeLogInstance.info);
-      sinon.assert.calledWith(fakeLogInstance.info, { _label: 'INFO', some: 'data' }, 'message');
+      sinon.assert.calledWith(fakeLogInstance.info, data, 'message');
     });
 
 
@@ -219,16 +219,6 @@ describe(dirname, function () {
       log('info', 'message', data);
       sinon.assert.calledOnce(fakeLogInstance.info._original);
       sinon.assert.calledWith(fakeLogInstance.info._original, expected, 'message');
-    });
-
-    it('does not mutate the object passed to the logger', function () {
-      process.env.CLAY_LOG_PLUGINS = 'heap';
-      const fakeLogInstance = createFakeLogger()(),
-        log = fn(fakeLogInstance),
-        data = { some: 'data' };
-
-      log('info', 'message', data);
-      expect(data).to.deep.equal({ some: 'data' });
     });
 
     it('doesn\'t log memory usage if CLAY_LOG_PLUGINS does not contain "heap"', function () {


### PR DESCRIPTION
This commit removes the use of `_.cloneDeep` on additional context
passed to a `log` call (third positional argument).

Cloning `data` introduced a breaking change for individuals passing
objects with non-enumerable properties as the `data` argument.

**Note:**

This reversion re-introduces the risk of mutation when paired with
plug-ins. It also restores the built-in mutation that will append a
`._label` attribute to any `data` argument.

The README was updated to reflect those risks and explain how
they can be managed through careful usage.

https://github.com/clay/clay-log/issues/21