### PR TITLE
fix: exclude hostname from clay-log json

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,10 +69,13 @@ function resolvePluginPath(dirname) {
  * Initialize the logger.
  *
  * @param  {Object} args
+ * @param  {string} args.name
+ * @param  {boolean} args.omitHost
+ * @param  {object} args.meta
  * @return {Function}
  */
 function init(args) {
-  var output, stream, pretty, name, meta;
+  let output, stream, pretty, name, meta, omitHost;
 
   checkArgs(args);
 
@@ -80,6 +83,7 @@ function init(args) {
   stream = getOutput(args);
   pretty = getPrettyPrint(args);
   name = args.name;
+  omitHost = args.omitHost || false;
   meta = args.meta || undefined;
 
   if (pretty) {
@@ -91,6 +95,7 @@ function init(args) {
   // level is set via an env var called `LOG`
   logger = pino({
     name: name,
+    base: omitHost ? { pid: process.pid } : undefined,
     level: process.env.LOG || 'info'
   }, output);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-log",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-log",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "An isomorphic logging module for Clay projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In some use cases, we do not want the application to ship logs with the "hostname" field populated as it can create conflict with other tools. For example, if present Datadog is forced to drop any host-related tags such as cluster name, etc. difficulting some filter capabilities. 

see: https://github.com/DataDog/datadog-agent/issues/14860

```js
// default
let myLogger = init({ name: 'my-logger' });
myLogger('info', 'message text');
```
```json
{"level":30,"time":1729715181162,"msg":"message text","pid":34323,"hostname":"MBP14M2.local","name":"my-logger","_label":"INFO","v":1}
```


```js
// excluding the hostname
let myLogger = init({ name: 'my-logger', omitHost: true });
myLogger('info', 'message text');
```
```json
{"level":30,"time":1729715193235,"msg":"message text","pid":34330,"name":"my-logger","_label":"INFO","v":1}
```